### PR TITLE
Scroll position sync support

### DIFF
--- a/markdown_preview/main_container.py
+++ b/markdown_preview/main_container.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk, Gio, GLib
 from .utils import get_backends_dict, init_gettext, recognize_format
 from .webview_manager import MdWebViewManager
 from .constants import MD_PREVIEW_KEY_BASE, MARKDOWN_SPLITTERS, BASE_TEMP_NAME
+from .source_lines import SourceLinesExtension
 
 AVAILABLE_BACKENDS = get_backends_dict()
 if AVAILABLE_BACKENDS['p3md']:
@@ -278,6 +279,9 @@ class MdMainContainer(Gtk.Box):
 			return
 		start, end = doc.get_bounds()
 		unsaved_text = doc.get_text(start, end, True)
+		cursor_position = doc.get_property("cursor-position")
+		text_iter = doc.get_iter_at_offset(cursor_position)
+		self._webview_manager.set_cursor_position (text_iter.get_line()+1, text_iter.get_line_offset()+1)
 		unsaved_text = unsaved_text.encode('utf-8').decode()
 		if self._file_format == 'html':
 			html_content = self.get_html_from_html(unsaved_text)
@@ -343,9 +347,10 @@ class MdMainContainer(Gtk.Box):
 			  'rel="stylesheet" href="' + self._stylesheet + '" /></head><body>'
 		post_string = '</body></html>'
 
+		extensions = [SourceLinesExtension()]+self._p3md_extensions
 		html_string = markdown.markdown(
 			unsaved_text,
-			extensions=self._p3md_extensions
+			extensions=extensions
 		)
 		html_content = pre_string + html_string + post_string
 		return html_content

--- a/markdown_preview/prefs/prefs_dialog.py
+++ b/markdown_preview/prefs/prefs_dialog.py
@@ -160,7 +160,7 @@ class MdConfigWidget(Gtk.Box):
 			return
 
 		command = 'pandoc $INPUT_FILE %s'
-		options = '--metadata pagetitle=Preview'
+		options = '-f commonmark+sourcepos --metadata pagetitle=Preview'
 		accept_css = True
 		# TODO........
 

--- a/markdown_preview/source_lines.py
+++ b/markdown_preview/source_lines.py
@@ -1,0 +1,60 @@
+# python3 -m markdown -x source_lines:SourceLinesExtension example.md
+
+from markdown.extensions import Extension
+from markdown.blockparser import BlockParser
+from markdown.blockprocessors import BlockProcessor
+import re
+import types
+import xml.etree.ElementTree as etree
+
+def set_source_position(block, line):
+   class BlockWithSourcePosition(type(block)):
+      def set_source_position(self, line):
+         self.source_line = line
+         return self
+   return BlockWithSourcePosition(block).set_source_position(line)
+
+def parseBlocks(self, parent, _blocks):
+   if not BlockParser.first_run:
+      self._parseBlocks(parent, _blocks)
+      return
+   BlockParser.first_run = False
+   source_line = 1
+   blocks = []
+   for b in _blocks:
+      new_lines = re.search('[^\n]|$', b, re.MULTILINE).start()
+      blocks.append(set_source_position(b, source_line+new_lines))
+      source_line += b.count('\n')+2
+   self._parseBlocks(parent, blocks)
+
+def block_processor_run(self, parent, blocks):
+   if len(parent)>0 and not parent[-1].get("source-line"):
+      parent[-1].set("source-line", str(BlockParser.source_line))
+      setattr(BlockParser, "source_line", None)
+   try:
+      setattr(BlockParser, "source_line", blocks[0].source_line)
+   except Exception:
+      pass
+   result = self._run(parent, blocks)
+   if len(parent)>0 and not parent[-1].get("source-line") and BlockParser.source_line:
+      parent[-1].set("source-line", str(BlockParser.source_line))
+      setattr(BlockParser, "source_line", None)
+   return result
+
+_parseBlocks = BlockParser.parseBlocks
+BlockProcessor_run = BlockProcessor.run
+
+class SourceLinesExtension(Extension):
+    def extendMarkdown(self, md):
+        BlockParser._parseBlocks = _parseBlocks
+        BlockParser.parseBlocks = parseBlocks
+        BlockParser.first_run = True
+        md.parser._parseBlocks = types.MethodType(BlockParser._parseBlocks, md.parser)
+        md.parser.parseBlocks = types.MethodType(parseBlocks, md.parser)
+        setattr(BlockParser, "source_line", None)
+
+        BlockProcessor._run = BlockProcessor_run
+        BlockProcessor.run = block_processor_run
+        for b in md.parser.blockprocessors:
+           b._run = b.run
+           b.run = types.MethodType(block_processor_run, b)

--- a/org.gnome.gedit.plugins.markdown_preview.gschema.xml
+++ b/org.gnome.gedit.plugins.markdown_preview.gschema.xml
@@ -83,7 +83,7 @@
       <description></description>
     </key>
     <key type="as" name="pandoc-command">
-      <default>['pandoc', '-s', '$INPUT_FILE', '--metadata', 'pagetitle=Preview']</default>
+      <default>['pandoc', '-f', 'commonmark+sourcepos', '-s', '$INPUT_FILE', '--metadata', 'pagetitle=Preview']</default>
       <summary>Pandoc rendering command line</summary>
       <description>
         The command line used for pandoc rendering. It has to return HTML code


### PR DESCRIPTION
Added support for syncing the scroll position of the webview with the position of the cursor.

I also tried to create a `python3-markdown` plugin as described in my comment in issue #35, but I could only find a [hack solution](https://github.com/Antonio-R1/gedit-plugin-markdown_preview/blob/0401dd85a604838cefe3205ac4671128d34f42bf/markdown_preview/source_lines.py). For lists and code blocks, for example, it only outputs the source line of the beginning of the list or code block, respectively.

The `sourcepos` extension from `pandoc` is only available for the `commonmark`, `commonmark_x` and `gfm` formats. This pull request changes the input format to `commonmark` and for using features like tables etc., the required extensions needs to be enabled or one of the other two formats can be used.

Currently, the position is always synced when the document is reloaded, but I think a new option in the preference window can be added for activating or deactivating the synchronization of the scroll position.